### PR TITLE
:factory: Accept string argument in .query() #20

### DIFF
--- a/README.md
+++ b/README.md
@@ -284,9 +284,9 @@ await blogs.url(`/${id}`).delete().res()
 const noMoreBlogs = blogs.url("http://mywebsite.org/", true)
 ```
 
-#### query(qp: Object)
+#### query(qp: object | string)
 
-Converts a javascript object to query parameters, then appends this query string to the current url.
+Converts a javascript object to query parameters, then appends this query string to the current url. String values are used as the query string verbatim.
 
 ```js
 let w = wretch("http://example.com")
@@ -295,6 +295,8 @@ w = w.query({ a: 1, b: 2 })
 // url is now http://example.com?a=1&b=2
 w = w.query({ c: 3, d: [4, 5] })
 // url is now http://example.com?c=3&d=4&d=5
+w = w.query("five&six&seven=eight")
+// url is now http://example.com?five&six&seven=eight
 ```
 
 #### options(options: Object, mixin: boolean = true)

--- a/test/wretch.spec.ts
+++ b/test/wretch.spec.ts
@@ -295,6 +295,9 @@ describe("Wretch", function() {
         const obj5 = obj4.query({c: 6, d: [7, 8]})
         expect(obj4["_url"]).toBe(`${_URL}?a=1%21&b=2`)
         expect(obj5["_url"]).toBe(`${_URL}?c=6&d=7&d=8`)
+        const obj6 = obj5.query('Literal[]=Query&String')
+        expect(obj5["_url"]).toBe(`${_URL}?c=6&d=7&d=8`)
+        expect(obj6["_url"]).toBe(`${_URL}?Literal[]=Query&String`)
     })
 
     it("should set the Accept header", async function() {


### PR DESCRIPTION
Allow `.query` to accept a literal string so it can be composed arbitrarily by a caller.

Add test case and documentation.