### PR TITLE
Add CDN usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,6 +145,11 @@ externalApi
 ```sh
 npm i wretch
 ```
+## CDN
+
+```js
+<script src="https://cdn.jsdelivr.net/npm/wretch@1/dist/bundle/wretch.min.js"></script>
+```
 
 ## Clone
 


### PR DESCRIPTION
I added a [jsDelivr CDN link](https://www.jsdelivr.com/package/npm/wretch) to your readme to make it easier to use. jsDelivr is the fastest opensource CDN available and built specifically for production usage.