### PR TITLE
:bug: Add default errorType to response object

### DIFF
--- a/src/resolver.ts
+++ b/src/resolver.ts
@@ -51,7 +51,7 @@ export const resolver = (wretcher: Wretcher) => {
         if (!response.ok) {
             return response[conf.errorType || "text"]().then(msg => {
                 const err = new Error(msg)
-                err[conf.errorType] = msg
+                err[conf.errorType || "text"] = msg
                 err["status"] = response.status
                 err["response"] = response
                 throw err


### PR DESCRIPTION
Love this package! However, during some test I found that unless `errorType()` is called during the chain the response object for errors ends up with a shape of `{ null: ..., status: ..., response: ...}`. This PR adds the fallback of "text" to the response object just like line 52 `response[conf.errorType || "text"]`