### PR TITLE
:bug: Pass method and more options to defer callback 

### DIFF
--- a/src/wretcher.ts
+++ b/src/wretcher.ts
@@ -190,12 +190,13 @@ export class Wretcher {
     }
 
     private method(method, options = {}, body = null) {
-        const baseWretcher =
+        let baseWretcher =
             !body ? this :
             typeof body === "object" ? this.json(body) :
             this.body(body)
+        baseWretcher = baseWretcher.options({ ...options, method })
         const deferredWretcher = baseWretcher._deferredChain.reduce((acc: Wretcher, curr) => curr(acc, acc._url, acc._options), baseWretcher)
-        return resolver(deferredWretcher.options({ ...options, method }))
+        return resolver(deferredWretcher)
     }
 
     /**

--- a/test/node/wretch.spec.ts
+++ b/test/node/wretch.spec.ts
@@ -487,6 +487,8 @@ describe("Wretch", function () {
     it("should chain actions that will be performed just before the request is sent", async function () {
         const w = wretch(_URL + "/basicauth")
             .defer((w, url, opts) => {
+                expect(opts.method).toBe('GET')
+                expect(opts.q).toBe('a')
                 expect(url).toBe(_URL + "/basicauth")
                 return w.auth("toto")
             })
@@ -494,7 +496,7 @@ describe("Wretch", function () {
 
         const result = await w
             .options({ token: "Basic d3JldGNoOnJvY2tz" })
-            .get()
+            .get({ q: 'a' })
             .text()
         expect(result).toBe("ok")
     })


### PR DESCRIPTION
The problem

```js
wretcher().defer((req, url, options) => {
  // options is empty {}
}).get({ a: 1 })
```

I can not get the `method` or `other option` in the `defer`