### PR TITLE
Update resolver.ts - Add null verification to .get("Content-Type")

### DIFF
--- a/src/resolver.ts
+++ b/src/resolver.ts
@@ -62,7 +62,7 @@ export const resolver = <T, Chain, R>(wretch: T & Wretch<T, Chain, R>) => {
         }
         return response.text().then((body: string) => {
           err.message = body
-          if (config.errorType === "json" || response.headers.get("Content-Type").split(";")[0] === "application/json") {
+          if (config.errorType === "json" || response.headers.get("Content-Type")?.split(";")[0] === "application/json") {
             try { err.json = JSON.parse(body) } catch (e) { /* ignore */ }
           }
           err.text = body


### PR DESCRIPTION
The line response.headers.get("Content-Type").split(";")[0] is missing a ? before the call to "split". The Content-Type header may not be filled if the response has no body (e.g., in responses that only return a status code). When that happens, you get the following error: TypeError: Cannot read properties of null (reading 'split')
              at file://.../node_modules/wretch/dist/resolver.js:44:88
              at process.processTicksAndRejections (node:internal/process/task_queues:95:5)
              at <your app's call stack>

This verification handles this case.