### PR TITLE
Fix .addons typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -543,7 +543,7 @@ const form = {
 
 // Will append the following keys to the FormData payload:
 // "duck", "duckProperties[beak][color]", "duckProperties[legs]"
-wretch("...").addons(FormDataAddon).formData(form, ["ignored"]).post();
+wretch("...").addon(FormDataAddon).formData(form, ["ignored"]).post();
 ```
 
 ### [FormUrl 🔗](https://elbywan.github.io/wretch/api/interfaces/addons_formUrl.FormUrlAddon.html)


### PR DESCRIPTION
It's singular, not plural

Thanks for making wretch! It's great