### PR TITLE
fix(core): avoid double slashes when joining base URL and path

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2158,6 +2158,7 @@
       "integrity": "sha512-6JSSaBZmsKvEkbRUkf7Zj7dru/8ZCrJxAqArcLaVMee5907JdtEbKGsZ7zNiIm/UAkpGUkaSMZEXShnN2D1HZA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.46.1",
         "@typescript-eslint/types": "8.46.1",
@@ -2693,6 +2694,7 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -3956,7 +3958,8 @@
     "node_modules/devtools-protocol": {
       "version": "0.0.1508733",
       "dev": true,
-      "license": "BSD-3-Clause"
+      "license": "BSD-3-Clause",
+      "peer": true
     },
     "node_modules/diff": {
       "version": "5.2.0",
@@ -4187,6 +4190,7 @@
       "integrity": "sha512-t5aPOpmtJcZcz5UJyY2GbvpDlsK5E8JqRqoKtfiKE3cNh437KIqfJr3A3AKf5k64NPx6d0G3dno6XDY05PqPtw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -7519,6 +7523,7 @@
       "version": "4.52.5",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/estree": "1.0.8"
       },
@@ -8366,6 +8371,7 @@
       "version": "5.9.3",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"

--- a/src/core.ts
+++ b/src/core.ts
@@ -1,4 +1,4 @@
-import { mix, extractContentType, isLikelyJsonMime } from "./utils.js"
+import { mix, extractContentType, isLikelyJsonMime, joinUrl, splitUrlQuery } from "./utils.js"
 import { JSON_MIME, CATCHER_FALLBACK } from "./constants.js"
 import { resolver, WretchError } from "./resolver.js"
 import type { Wretch, WretchOptions } from "./types.js"
@@ -20,15 +20,10 @@ export const core: Wretch = {
     return { ...this, _fetch: fetchImpl }
   },
   url(_url, replace = false) {
-    if (replace)
-      return { ...this, _url }
-    const idx = this._url.indexOf("?")
-    return {
-      ...this,
-      _url: idx > -1 ?
-        this._url.slice(0, idx) + _url + this._url.slice(idx) :
-        this._url + _url
-    }
+    if (replace) return { ...this, _url }
+
+    const { path, query } = splitUrlQuery(this._url)
+    return { ...this, _url: joinUrl(path, _url) + query }
   },
   options(options, replace = false) {
     return { ...this, _options: replace ? options : mix(this._options, options) }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -23,3 +23,18 @@ export const mix = (one: object, two: object, mergeArrays = false) => {
   }
   return acc
 }
+
+export function splitUrlQuery(url: string) {
+  const i = url.indexOf("?")
+  return i === -1
+    ? { path: url, query: "" }
+    : { path: url.slice(0, i), query: url.slice(i) }
+}
+
+export function joinUrl(base: string, next: string) {
+  if (!base) return next
+  if (!next) return base
+  return base.endsWith("/") && next.startsWith("/")
+    ? base + next.slice(1)
+    : base + next
+}

--- a/test/shared/wretch.spec.ts
+++ b/test/shared/wretch.spec.ts
@@ -461,6 +461,31 @@ export function createWretchTests(ctx: TestContext): void {
       expect(obj7["_url"]).toBe(`${_URL}/test?a=1%21&b=2&c=6&d=7&d=8&Literal[]=Query&String`)
     })
 
+    it("should not introduce a double slash when base url ends with '/' and request path starts with '/'", async function () {
+      const shortCircuit = () => (_next: FetchLike) => (url: string, opts: WretchOptions): Promise<WretchResponse> =>
+        Promise.resolve({
+          ok: true,
+          text: () => Promise.resolve(opts.method + "@" + url)
+        } as WretchResponse)
+
+      const base = `${_URL}/`
+      const result = await wretch()
+        .middlewares([shortCircuit()])
+        .url(base)
+        .get("/text")
+        .text()
+
+      expect(result).toBe(`GET@${_URL}/text`)
+    })
+
+    it("should keep the query string at the end when appending url segments", async function () {
+      const obj1 = wretch("...")
+      const obj2 = obj1.url(`${_URL}?a=1`, true)
+      const obj3 = obj2.url("/test")
+
+      expect(obj3["_url"]).toBe(`${_URL}/test?a=1`)
+    })
+
     it("should accept multiple addons at once", async function () {
       const w = wretch(`${_URL}/basicauth`)
         .addon([BasicAuthAddon, QueryStringAddon])


### PR DESCRIPTION
This PR fixes an edge case where joining a base URL ending with `/` and a request path starting with `/` produced a double slash (`//`) in the final request URL.

The change is intentionally minimal and keeps Wretch's existing concatenation semantics intact.

Includes a regression test reproducing the issue.

Closes https://github.com/elbywan/wretch/issues/295