### PR TITLE
:art: Narrow AbortAddon controller() return type to AbortController

### DIFF
--- a/src/addons/abort.ts
+++ b/src/addons/abort.ts
@@ -79,7 +79,7 @@ export interface AbortResolver {
    * c.abort()
    * ```
    */
-  controller: <T, C extends AbortResolver, R, E>(this: C & WretchResponseChain<T, C, R, E>) => [any, this]
+  controller: <T, C extends AbortResolver, R, E>(this: C & WretchResponseChain<T, C, R, E>) => [AbortController, this]
   /**
    * Catches an AbortError and performs a callback.
    */

--- a/test/types/abort-controller.ts
+++ b/test/types/abort-controller.ts
@@ -1,0 +1,29 @@
+import wretch from "../../src/index.js"
+import AbortAddon from "../../src/addons/abort.js"
+
+// `.controller()` returns the request's AbortController paired with the response
+// chain. The first element must be typed as `AbortController` — not `any` — so
+// that `.abort()`, `.signal`, etc. are statically checked at the call site.
+async function controllerReturnType() {
+  const [controller, chain] = wretch("https://example.com")
+    .addon(AbortAddon())
+    .get()
+    .controller()
+
+  // The controller exposes the real AbortController surface.
+  const expected: AbortController = controller
+  const signal: AbortSignal = controller.signal
+  controller.abort()
+
+  // @ts-expect-error the controller is an `AbortController`, not `any`, so
+  // accessing a member that does not exist on it is a type error.
+  controller.notAnAbortControllerMethod()
+
+  // The second element is still the response chain and keeps its methods.
+  void chain.onAbort(() => {})
+
+  return { expected, signal }
+}
+
+// Keep the helper referenced so the file is checked but never executed.
+void [controllerReturnType]


### PR DESCRIPTION
## What

`.controller()` is typed as `() => [any, this]`, so the first element of the returned pair is `any`. At runtime it is always the request's `AbortController` (created in `beforeRequest`), so this narrows the type to `[AbortController, this]`.

## Why

With `any`, callers lose all type safety on the returned controller — the documented `c.abort()` usage isn't checked, and typos slip through silently:

```ts
const [c, w] = wretch(url).addon(AbortAddon()).get().controller()
c.abort()   // now type-checked
c.signl     // now a compile error instead of silently `any`
```

This is a type-only change — runtime behaviour is unchanged. (Same spirit as #314.)

## Tests

Adds `test/types/abort-controller.ts`, which asserts the narrowed return type and includes a `@ts-expect-error` that fails if the type ever regresses back to `any`. `npm run test:types` and `npm run test:node` both pass locally.
